### PR TITLE
Update to text-davinci-003 to gpt-3.5-turbo

### DIFF
--- a/app/models/open_ai_service.rb
+++ b/app/models/open_ai_service.rb
@@ -5,7 +5,7 @@ class OpenAiService
 
     res = client.completions(
       parameters: {
-        model: "text-davinci-003",
+        model: "gpt-3.5-turbo",
         prompt: input,
         max_tokens: 256,
         top_p: 1,


### PR DESCRIPTION
GPT-3 にアップデート

https://openai.com/blog/introducing-chatgpt-and-whisper-apis

> Model: The ChatGPT model family we are releasing today, gpt-3.5-turbo, is the same model used in the ChatGPT product. It is priced at $0.002 per 1k tokens, which is 10x cheaper than our existing GPT-3.5 models. It’s also our best model for many non-chat use cases—we’ve seen early testers migrate from text-davinci-003 to gpt-3.5-turbo with only a small amount of adjustment needed to their prompts.

